### PR TITLE
(frontend) gh pages deployment

### DIFF
--- a/.github/workflows/pages-frontend.yml
+++ b/.github/workflows/pages-frontend.yml
@@ -1,0 +1,61 @@
+name: Deploy Frontend to GitHub Pages
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: The-Nest-Trail-Frontend
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: The-Nest-Trail-Frontend/package-lock.json
+
+      - name: Install
+        run: npm ci
+
+      - name: Build
+        # Provide API URL at build time (set this secret in repo Settings > Secrets and variables > Actions)
+        env:
+          VITE_API_URL: ${{ secrets.VITE_API_URL }}
+        run: npm run build
+
+      # Optional but recommended: SPA fallback so refresh/deep links work
+      - name: Copy 404 for SPA
+        run: cp dist/index.html dist/404.html
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: The-Nest-Trail-Frontend/dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/The-Nest-Trail-Frontend/src/App.jsx
+++ b/The-Nest-Trail-Frontend/src/App.jsx
@@ -4,7 +4,7 @@ import ChatTestPage from './pages/ChatTestPage';
 
 function App() {
   return (
-    <Router>
+    <Router basename={import.meta.env.BASE_URL}>
       <Routes>
         <Route path="/" element={<HomePage/>} />
         <Route path="/chat-test" element={<ChatTestPage/>} />

--- a/The-Nest-Trail-Frontend/src/api/api.js
+++ b/The-Nest-Trail-Frontend/src/api/api.js
@@ -1,5 +1,5 @@
 // base backend url
-const API_URL = 'http://localhost:5050'
+const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:5050';
 
 
 // test api call to backend

--- a/The-Nest-Trail-Frontend/vite.config.js
+++ b/The-Nest-Trail-Frontend/vite.config.js
@@ -2,6 +2,7 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react-swc'
 
 // https://vite.dev/config/
-export default defineConfig({
+export default defineConfig(({ mode }) => ({
   plugins: [react()],
-})
+  base: mode === 'production' ? '/The-Nest-Trail/' : '/', // repo name here
+}))


### PR DESCRIPTION

## Changes
_List Changes Introduced by this PR_
1.	Add GitHub Actions workflow to build and deploy the frontend from the The-Nest-Trail-Frontend subfolder to GitHub Pages (.github/workflows/pages-frontend.yml).
2.	Configure Vite base path and React Router basename for GitHub Pages compatibility (conditional base in vite.config.js, basename={import.meta.env.BASE_URL} in App.jsx).
3.	Switch frontend API base to use VITE_API_URL with a localhost fallback for development.

## Purpose
•	Enable automated, reproducible deployment of the frontend to GitHub Pages on merges to main.
•	Ensure the app loads correctly at the subpath https://bizznest.github.io/The-Nest-Trail/ (no blank screen, assets resolve, client-side routes work).
•	Allow the frontend to target the Railway backend via environment variable (VITE_API_URL) without hardcoding URLs.

## Approach
•	CI/CD: Introduce a Pages workflow that checks out code, builds from The-Nest-Trail-Frontend, uploads the dist artifact, and deploys to GitHub Pages.
•	Routing/Assets: Configure Vite’s base to '/The-Nest-Trail/' in production and / in development; set React Router’s basename to import.meta.env.BASE_URL.
•	Env-based API: Replace hardcoded http://localhost:5050 with import.meta.env.VITE_API_URL || 'http://localhost:5050' so dev remains unchanged and prod points to Railway.


_If this closes an issue, name it here. If it doesn't, remove this line_
Closes #051
